### PR TITLE
Respect publish_in_ical for organizer feeds

### DIFF
--- a/backend/.sqlx/query-b6c785df6b7307e354ac64c6a1dcdb610b1e5452d1be816f0cd01419f0f96c21.json
+++ b/backend/.sqlx/query-b6c785df6b7307e354ac64c6a1dcdb610b1e5452d1be816f0cd01419f0f96c21.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT\n            e.id, e.title_de, e.title_en, e.description_de, e.description_en,\n            e.start_date_time, e.end_date_time, e.event_url, e.location,\n            o.location as organizer_location\n        FROM events e\n        JOIN organizers o ON e.organizer_id = o.id\n        WHERE e.organizer_id = $1 AND e.publish_app = true\n        ORDER BY e.start_date_time ASC\n        ",
+  "query": "\n        SELECT\n            e.id, e.title_de, e.title_en, e.description_de, e.description_en,\n            e.start_date_time, e.end_date_time, e.event_url, e.location,\n            o.location as organizer_location\n        FROM events e\n        JOIN organizers o ON e.organizer_id = o.id\n        WHERE e.organizer_id = $1 AND e.publish_in_ical = true\n        ORDER BY e.start_date_time ASC\n        ",
   "describe": {
     "columns": [
       {
@@ -72,5 +72,5 @@
       true
     ]
   },
-  "hash": "f2404ce1d530c40eae19b771242615b1957a46408207e69195cbf18dfd42f707"
+  "hash": "b6c785df6b7307e354ac64c6a1dcdb610b1e5452d1be816f0cd01419f0f96c21"
 }

--- a/backend/src/responses.rs
+++ b/backend/src/responses.rs
@@ -36,12 +36,6 @@ pub struct SetupTokenInfoResponse {
 }
 
 #[derive(Debug, Serialize, ToSchema)]
-pub struct NewsletterTemplateResponse {
-    pub subject: String,
-    pub html_body: String,
-}
-
-#[derive(Debug, Serialize, ToSchema)]
 pub struct NewsletterDataResponse {
     pub subject: String,
     pub next_week_events: Vec<EventWithOrganizer>,

--- a/backend/src/routes/ical.rs
+++ b/backend/src/routes/ical.rs
@@ -214,7 +214,7 @@ pub(crate) async fn get_organizer_events_ical(
             o.location as organizer_location
         FROM events e
         JOIN organizers o ON e.organizer_id = o.id
-        WHERE e.organizer_id = $1 AND e.publish_app = true
+        WHERE e.organizer_id = $1 AND e.publish_in_ical = true
         ORDER BY e.start_date_time ASC
         "#,
         organizer_id


### PR DESCRIPTION
## Summary
- use the publish_in_ical flag when building organizer-specific iCal feeds so hidden events stay private
- remove the unused NewsletterTemplateResponse struct and update the SQLx cache for the revised query

## Testing
- SQLX_OFFLINE=true cargo clippy --all-targets --all-features -- -D warnings
- SQLX_OFFLINE=true cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d1afe9e2688330b2ddd4efda20b879