### PR TITLE
Improve newsletter preview email handling

### DIFF
--- a/frontend/app/(app)/newsletter/page.tsx
+++ b/frontend/app/(app)/newsletter/page.tsx
@@ -114,11 +114,10 @@ export default function NewsletterPage() {
 	}
 
 	const handleSendPreview = () => {
-		if (newsletterData) {
-			const fullHtml = generateNewsletterHTML(newsletterData, customText)
+		if (newsletterData && generatedHtml) {
 			previewMutation.mutate({
 				subject: newsletterData.subject,
-				html: fullHtml
+				html: generatedHtml
 			})
 		}
 	}


### PR DESCRIPTION
## Summary
- ensure the send preview action reuses the rendered HTML before calling the API
- add structured tracing logs for newsletter preview delivery outcomes and configuration issues

## Testing
- bun run fmt
- cargo fmt

------
https://chatgpt.com/codex/tasks/task_e_68f189c198e88330b130046f42d647b7