### PR TITLE
fix: gate public event detail API on publish_app, not publish_web

### DIFF
--- a/backend/.sqlx/query-ed907168a34aba443650a63fe980e2fb9aaadb82babac532b012abbfec0b882e.json
+++ b/backend/.sqlx/query-ed907168a34aba443650a63fe980e2fb9aaadb82babac532b012abbfec0b882e.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT e.id, e.organizer_id, o.name AS organizer_name, o.organizer_kind as \"organizer_kind: OrganizerKind\", e.title_de, e.title_en, e.description_de, e.description_en, e.start_date_time, e.end_date_time, e.event_url, e.location\n        FROM events e\n        INNER JOIN organizers o ON e.organizer_id = o.id\n        WHERE e.id = $1 AND e.publish_web = true\n        ",
+  "query": "\n        SELECT e.id, e.organizer_id, o.name AS organizer_name, o.organizer_kind as \"organizer_kind: OrganizerKind\", e.title_de, e.title_en, e.description_de, e.description_en, e.start_date_time, e.end_date_time, e.event_url, e.location, e.publish_web\n        FROM events e\n        INNER JOIN organizers o ON e.organizer_id = o.id\n        WHERE e.id = $1 AND e.publish_app = true\n        ",
   "describe": {
     "columns": [
       {
@@ -72,6 +72,11 @@
         "ordinal": 11,
         "name": "location",
         "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "publish_web",
+        "type_info": "Bool"
       }
     ],
     "parameters": {
@@ -91,8 +96,9 @@
       false,
       false,
       true,
-      true
+      true,
+      false
     ]
   },
-  "hash": "a5eae13b726130c5c69c475466aed640dc01c51d20e5ce66f5d26ccd4e963db4"
+  "hash": "ed907168a34aba443650a63fe980e2fb9aaadb82babac532b012abbfec0b882e"
 }

--- a/backend/src/responses.rs
+++ b/backend/src/responses.rs
@@ -93,6 +93,7 @@ pub struct PublicEventResponse {
     pub end_date_time: DateTime<Utc>,
     pub event_url: Option<String>,
     pub location: Option<String>,
+    pub publish_web: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]

--- a/backend/src/routes/public_events.rs
+++ b/backend/src/routes/public_events.rs
@@ -29,6 +29,7 @@ struct PublicEventWithOrganizer {
     end_date_time: DateTime<Utc>,
     event_url: Option<String>,
     location: Option<String>,
+    publish_web: bool,
 }
 
 #[derive(Debug, FromRow)]
@@ -72,7 +73,7 @@ pub(crate) async fn list_public_events(
     }
 
     let mut builder = QueryBuilder::<Postgres>::new(
-        "SELECT e.id, e.organizer_id, o.name AS organizer_name, o.organizer_kind, e.title_de, e.title_en, e.description_de, e.description_en, e.start_date_time, e.end_date_time, e.event_url, e.location FROM events e INNER JOIN organizers o ON e.organizer_id = o.id",
+        "SELECT e.id, e.organizer_id, o.name AS organizer_name, o.organizer_kind, e.title_de, e.title_en, e.description_de, e.description_en, e.start_date_time, e.end_date_time, e.event_url, e.location, e.publish_web FROM events e INNER JOIN organizers o ON e.organizer_id = o.id",
     );
 
     // Only show events that are published in the app
@@ -125,6 +126,7 @@ pub(crate) async fn list_public_events(
             end_date_time: event.end_date_time,
             event_url: event.event_url,
             location: event.location,
+            publish_web: event.publish_web,
         })
         .collect();
 
@@ -250,10 +252,10 @@ pub(crate) async fn get_public_event(
     let event = sqlx::query_as!(
         PublicEventWithOrganizer,
         r#"
-        SELECT e.id, e.organizer_id, o.name AS organizer_name, o.organizer_kind as "organizer_kind: OrganizerKind", e.title_de, e.title_en, e.description_de, e.description_en, e.start_date_time, e.end_date_time, e.event_url, e.location
+        SELECT e.id, e.organizer_id, o.name AS organizer_name, o.organizer_kind as "organizer_kind: OrganizerKind", e.title_de, e.title_en, e.description_de, e.description_en, e.start_date_time, e.end_date_time, e.event_url, e.location, e.publish_web
         FROM events e
         INNER JOIN organizers o ON e.organizer_id = o.id
-        WHERE e.id = $1 AND e.publish_web = true
+        WHERE e.id = $1 AND e.publish_app = true
         "#,
         id
     )
@@ -275,6 +277,7 @@ pub(crate) async fn get_public_event(
                 end_date_time: event.end_date_time,
                 event_url: event.event_url,
                 location: event.location,
+                publish_web: event.publish_web,
             };
             if let Some(cache) = &state.cache
                 && let Err(err) = cache.set_json(&cache_key, &public_event).await

--- a/frontend/app/e/[id]/page.tsx
+++ b/frontend/app/e/[id]/page.tsx
@@ -19,12 +19,7 @@ type Event = {
 	end_date_time: string
 	event_url?: string
 	location?: string
-	publish_app: boolean
-	publish_newsletter: boolean
-	publish_in_ical: boolean
 	publish_web: boolean
-	created_at: string
-	updated_at: string
 }
 
 type Organizer = {
@@ -82,6 +77,11 @@ export default async function PublicEventPage({
 	}
 
 	const event = await getPublicEvent(id)
+
+	if (!event.publish_web) {
+		notFound()
+	}
+
 	const organizer = event.organizer_id
 		? await getPublicOrganizer(event.organizer_id)
 		: null


### PR DESCRIPTION
## Summary
- Fix `GET /api/v1/public/events/{id}` filtering on `publish_web` while the list endpoint correctly used `publish_app`, causing 404s for app-published events with web sharing disabled.
- Add `publish_web` to `PublicEventResponse` so API consumers can see the flag without it acting as an access gate.
- Enforce `publish_web` on the `/e/[id]` share page so web visibility stays separate from API availability.

## Test plan
- [x] `cargo sqlx prepare` against local Postgres
- [x] `cargo test`
- [x] Verified SQL: event with `publish_app=true` and `publish_web=false` is returned by the new detail query but not the old one
- [ ] Confirm public API returns event detail when `publish_app=true`, `publish_web=false`
- [ ] Confirm `/e/{id}` returns 404 when `publish_web=false`
- [ ] Confirm share link action still hidden when `publish_web=false` in dashboard