### PR TITLE
docs: add Cursor Cloud setup instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,3 +242,19 @@ cargo test test_name
 - Check individual service READMEs in `backend/README.md` and `frontend/README.md`
 - Review OpenAPI documentation at `http://localhost:8080/api-docs/openapi.json`
 - Examine existing code patterns in `src/routes/` and `components/`
+
+## Cursor Cloud specific instructions
+
+The update script keeps dependencies fresh (`bun install` for the frontend, `cargo fetch` for the backend). It does NOT start services or create env files. Start services manually each session, in this order:
+
+1. Docker is installed but not managed by systemd. Start the daemon once per session: `sudo dockerd` (run it in a background terminal/tmux; it uses the `fuse-overlayfs` storage driver). Then start the database: `cd backend && docker compose up -d` (Postgres on host port `5422`, Redis on `6379`).
+2. Backend: `cd backend && SQLX_OFFLINE=true cargo run`. The `SQLX_OFFLINE=true` is REQUIRED on a fresh database. The `sqlx::query!` macros validate SQL at compile time; migrations only run at app startup, so a freshly-created DB has no schema yet and an online build (`cargo run` without the flag) fails with confusing `str` size errors. Offline mode uses the committed `.sqlx/` cache instead. Same applies to `cargo build`/`cargo clippy`/`cargo test` (CI sets `SQLX_OFFLINE=true`). After the backend has run once and migrations are applied, plain `cargo run` also works.
+3. Frontend: `cd frontend && bun run dev` (port 3000, proxies `/api/*` to the backend).
+
+Env files are local and untracked; create them if missing: `backend/.env` (`DATABASE_URL=postgres://cle:cle_password@localhost:5422/cle_db`, `REDIS_URL=redis://localhost:6379`, `ALLOWED_ORIGINS=http://localhost:3000`, `API_TOKEN_SECRET=<any-long-string>`) and `frontend/.env.local` (`BACKEND_URL=http://localhost:8080`, `NEXT_PUBLIC_COMMIT_HASH=local-dev`).
+
+Other gotchas:
+- Backend health endpoint is `/api/v1/healthcheck` (not `/health`).
+- No admin account exists by default and registration requires a setup token (admins normally issue these). To bootstrap a first account for testing, insert one directly via psql and complete setup in the browser: insert an `organizers` row plus an `accounts` row with `setup_token=<token>` and `setup_token_expires_at=NOW() + INTERVAL '7 days'`, then open `http://localhost:3000/register?token=<token>` to set a password and log in. Passwords must be ≥20 chars with upper/lower/digit/symbol (see `frontend/lib/password-policy.ts`).
+- The dashboard UI is in German.
+- Rust must be on a toolchain that supports edition 2024 (≥1.85); `rustup default stable` is used here.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the Campus Life Events monorepo and documents non-obvious startup caveats for future Cursor Cloud agents.

This PR only adds a `## Cursor Cloud specific instructions` section to `AGENTS.md`; no application code is modified. Dependency installation is handled by the VM update script (`bun install` + `cargo fetch`).

## Environment brought up

| Service | Command | Port |
|---|---|---|
| Postgres + Redis | `cd backend && docker compose up -d` | 5422 / 6379 |
| Backend API (Axum) | `cd backend && SQLX_OFFLINE=true cargo run` | 8080 |
| Frontend (Next.js) | `cd frontend && bun run dev` | 3000 |

## Key learnings captured in AGENTS.md

- `SQLX_OFFLINE=true` is required to build/run the backend against a fresh DB (migrations only run at app startup, so the `sqlx::query!` macros otherwise fail validating against an empty schema).
- Backend health endpoint is `/api/v1/healthcheck`.
- Bootstrapping a first account (no admin exists by default; registration needs a setup token) and the ≥20-char password policy.
- Docker daemon must be started manually (`sudo dockerd`, fuse-overlayfs).

## Verification

- `SQLX_OFFLINE=true cargo fmt --all -- --check`, `cargo clippy -- -D warnings`, `cargo test` (0 tests) all pass.
- `bun run lint` and `bun run build` pass for the frontend.
- End-to-end hello-world: completed token-based registration, logged into the dashboard, and created an event ("Hallo Welt Veranstaltung"), verified persisted in Postgres.

[Registration page](https://cursor.com/agents/bc-3d340b47-ea45-4468-8d90-00ee3e33da1e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F01_register_page.webp)
[Logged-in dashboard](https://cursor.com/agents/bc-3d340b47-ea45-4468-8d90-00ee3e33da1e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F02_dashboard.webp)
[Event created and listed](https://cursor.com/agents/bc-3d340b47-ea45-4468-8d90-00ee3e33da1e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F03_event_created.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d340b47-ea45-4468-8d90-00ee3e33da1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d340b47-ea45-4468-8d90-00ee3e33da1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

