### PR TITLE
feat: add ALLOWED_ORIGIN_SUFFIXES for dynamic CORS subdomain matching

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,6 +3,9 @@ API_TOKEN_SECRET=change-me-to-a-long-random-string-for-local-dev
 RUST_LOG=info
 SESSION_COOKIE_SECURE=false
 CACHE_TTL_SECONDS=60
+ALLOWED_ORIGINS=http://localhost:3000
+# Optional comma-separated host suffixes for dynamic CORS origins (e.g. Expo preview URLs)
+# ALLOWED_ORIGIN_SUFFIXES=.expo.app
 # SMTP settings for organizer invite emails
 # Leave unset to disable email sending in local development
 SMTP_HOST=localhost

--- a/backend/README.md
+++ b/backend/README.md
@@ -93,6 +93,7 @@ The generated files live in the `.sqlx/` directory and are committed to version 
 ## Operational notes
 
 - CORS origins are controlled via the `ALLOWED_ORIGINS` variable (comma-separated list). Defaults cover local dashboard development.
+- Use `ALLOWED_ORIGIN_SUFFIXES` (comma-separated host suffixes such as `.expo.app`) to allow any `http://` or `https://` origin whose host matches a suffix. Exact origins from `ALLOWED_ORIGINS` are always allowed as well.
 - Security headers (`X-Frame-Options`, `X-Content-Type-Options`, and HSTS) are injected globally through `tower-http` middleware.
 - iCal feeds are available under `/api/ical/...` and are used by the frontend to export event calendars.
 

--- a/backend/src/cors_config.rs
+++ b/backend/src/cors_config.rs
@@ -1,0 +1,208 @@
+use axum::http::{HeaderValue, Method, header};
+use tower_http::cors::{AllowOrigin, CorsLayer};
+use tracing::{info, warn};
+
+pub fn build_cors_layer() -> CorsLayer {
+    let raw_allowed_origins = std::env::var("ALLOWED_ORIGINS")
+        .unwrap_or_else(|_| "http://localhost:3000,https://localhost:3000".to_string());
+
+    let mut allowed_origins = Vec::new();
+    for origin in raw_allowed_origins.split(',') {
+        let trimmed = origin.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        match HeaderValue::from_str(trimmed) {
+            Ok(value) => allowed_origins.push(value),
+            Err(err) => warn!(
+                target: "startup",
+                component = "cors",
+                action = "parse_origin",
+                invalid_origin = trimmed,
+                %err,
+                "Ignoring invalid allowed origin"
+            ),
+        }
+    }
+
+    if allowed_origins.is_empty() {
+        warn!(
+            target: "startup",
+            component = "cors",
+            action = "parse_origin",
+            source = %raw_allowed_origins,
+            "No valid allowed origins configured; using default http://localhost:3000"
+        );
+        allowed_origins.push(HeaderValue::from_static("http://localhost:3000"));
+    }
+
+    let allowed_suffixes = parse_allowed_origin_suffixes();
+
+    let allowed_origin_strings: Vec<String> = allowed_origins
+        .iter()
+        .filter_map(|value| value.to_str().ok().map(str::to_string))
+        .collect();
+
+    info!(
+        target: "startup",
+        component = "cors",
+        action = "configure",
+        allowed_origins = ?allowed_origin_strings,
+        allowed_origin_suffixes = ?allowed_suffixes,
+        "Configured CORS allowed origins"
+    );
+
+    let mut layer = CorsLayer::new()
+        .allow_methods([
+            Method::GET,
+            Method::POST,
+            Method::PUT,
+            Method::DELETE,
+            Method::OPTIONS,
+        ])
+        .allow_headers([header::CONTENT_TYPE, header::AUTHORIZATION, header::COOKIE])
+        .allow_credentials(true);
+
+    layer = if allowed_suffixes.is_empty() {
+        layer.allow_origin(allowed_origins)
+    } else {
+        layer.allow_origin(AllowOrigin::predicate({
+            let exact = allowed_origins;
+            let suffixes = allowed_suffixes;
+            move |origin: &HeaderValue, _| origin_is_allowed(origin, &exact, &suffixes)
+        }))
+    };
+
+    layer
+}
+
+fn parse_allowed_origin_suffixes() -> Vec<String> {
+    let Ok(raw) = std::env::var("ALLOWED_ORIGIN_SUFFIXES") else {
+        return Vec::new();
+    };
+
+    let mut suffixes = Vec::new();
+    for entry in raw.split(',') {
+        let trimmed = entry.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        suffixes.push(normalize_suffix(trimmed));
+    }
+    suffixes
+}
+
+fn origin_is_allowed(
+    origin: &HeaderValue,
+    exact_origins: &[HeaderValue],
+    suffixes: &[String],
+) -> bool {
+    if exact_origins.iter().any(|allowed| allowed == origin) {
+        return true;
+    }
+
+    let Ok(origin_str) = origin.to_str() else {
+        return false;
+    };
+
+    suffixes
+        .iter()
+        .any(|suffix| origin_matches_suffix(origin_str, suffix))
+}
+
+fn normalize_suffix(suffix: &str) -> String {
+    if suffix.starts_with('.') {
+        suffix.to_string()
+    } else {
+        format!(".{suffix}")
+    }
+}
+
+fn origin_host(origin: &str) -> Option<&str> {
+    let (scheme, rest) = origin.split_once("://")?;
+    if scheme != "http" && scheme != "https" {
+        return None;
+    }
+
+    let host_with_port = rest.split('/').next()?;
+    let host = match host_with_port.rsplit_once(':') {
+        Some((host, port)) if port.chars().all(|c| c.is_ascii_digit()) => host,
+        _ => host_with_port,
+    };
+
+    Some(host)
+}
+
+fn origin_matches_suffix(origin: &str, suffix: &str) -> bool {
+    let Some(host) = origin_host(origin) else {
+        return false;
+    };
+
+    let normalized = normalize_suffix(suffix);
+    let apex = normalized.trim_start_matches('.');
+
+    host.ends_with(&normalized) || host == apex
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_expo_preview_subdomains() {
+        assert!(origin_matches_suffix(
+            "https://abc123.expo.app",
+            ".expo.app"
+        ));
+        assert!(origin_matches_suffix(
+            "https://myapp--branch.expo.app",
+            "expo.app"
+        ));
+    }
+
+    #[test]
+    fn rejects_unrelated_origins() {
+        assert!(!origin_matches_suffix(
+            "https://evil-expo.app.attacker.com",
+            ".expo.app"
+        ));
+        assert!(!origin_matches_suffix("https://notexpo.app", ".expo.app"));
+        assert!(!origin_matches_suffix(
+            "https://dev.neuland.app",
+            ".expo.app"
+        ));
+    }
+
+    #[test]
+    fn matches_apex_domain_when_configured() {
+        assert!(origin_matches_suffix("https://expo.app", ".expo.app"));
+    }
+
+    #[test]
+    fn rejects_invalid_origin_formats() {
+        assert!(!origin_matches_suffix("expo.app", ".expo.app"));
+        assert!(!origin_matches_suffix("ftp://foo.expo.app", ".expo.app"));
+    }
+
+    #[test]
+    fn exact_origin_matching_works() {
+        let exact = vec![HeaderValue::from_static("https://dev.neuland.app")];
+        let suffixes = vec![".expo.app".to_string()];
+
+        assert!(origin_is_allowed(
+            &HeaderValue::from_static("https://dev.neuland.app"),
+            &exact,
+            &suffixes
+        ));
+        assert!(origin_is_allowed(
+            &HeaderValue::from_static("https://preview.expo.app"),
+            &exact,
+            &suffixes
+        ));
+        assert!(!origin_is_allowed(
+            &HeaderValue::from_static("https://evil.example.com"),
+            &exact,
+            &suffixes
+        ));
+    }
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -2,6 +2,7 @@ mod api_token;
 mod app_state;
 mod authed_user;
 mod cache;
+mod cors_config;
 mod dto;
 mod email;
 mod error;
@@ -14,10 +15,10 @@ use std::net::SocketAddr;
 use std::path::Path;
 
 use axum::Router;
-use axum::http::{HeaderValue, Method, header};
+use axum::http::{HeaderValue, header};
 use sqlx::postgres::PgPoolOptions;
 use tokio::net::TcpListener;
-use tower_http::{cors::CorsLayer, set_header::SetResponseHeaderLayer};
+use tower_http::set_header::SetResponseHeaderLayer;
 use tracing::{error, info, warn};
 use tracing_subscriber::{EnvFilter, fmt::time::UtcTime};
 use utoipa::OpenApi;
@@ -168,69 +169,7 @@ async fn main() {
         api_token_hmac_key,
     };
 
-    // Configure CORS to be more restrictive
-    let raw_allowed_origins = std::env::var("ALLOWED_ORIGINS")
-        .unwrap_or_else(|_| "http://localhost:3000,https://localhost:3000".to_string());
-
-    let mut allowed_origins = Vec::new();
-    for origin in raw_allowed_origins.split(',') {
-        let trimmed = origin.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        match HeaderValue::from_str(trimmed) {
-            Ok(value) => allowed_origins.push(value),
-            Err(err) => warn!(
-                target: "startup",
-                component = "cors",
-                action = "parse_origin",
-                invalid_origin = trimmed,
-                %err,
-                "Ignoring invalid allowed origin"
-            ),
-        }
-    }
-
-    if allowed_origins.is_empty() {
-        warn!(
-            target: "startup",
-            component = "cors",
-            action = "parse_origin",
-            source = %raw_allowed_origins,
-            "No valid allowed origins configured; using default http://localhost:3000"
-        );
-        allowed_origins.push(HeaderValue::from_static("http://localhost:3000"));
-    }
-
-    let allowed_origin_strings: Vec<String> = allowed_origins
-        .iter()
-        .map(|value| {
-            value
-                .to_str()
-                .map(|s| s.to_string())
-                .unwrap_or_else(|_| String::new())
-        })
-        .collect();
-
-    info!(
-        target: "startup",
-        component = "cors",
-        action = "configure",
-        allowed_origins = ?allowed_origin_strings,
-        "Configured CORS allowed origins"
-    );
-
-    let cors = CorsLayer::new()
-        .allow_methods([
-            Method::GET,
-            Method::POST,
-            Method::PUT,
-            Method::DELETE,
-            Method::OPTIONS,
-        ])
-        .allow_origin(allowed_origins)
-        .allow_headers([header::CONTENT_TYPE, header::AUTHORIZATION, header::COOKIE])
-        .allow_credentials(true);
+    let cors = cors_config::build_cors_layer();
 
     // Note: Rate limiting and CSRF protection would require additional middleware
     // that's compatible with the current Axum version. These can be added later


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds support for `ALLOWED_ORIGIN_SUFFIXES`, a comma-separated list of host suffixes that dynamically allow CORS origins alongside the existing exact-match `ALLOWED_ORIGINS` list.

This enables Expo preview URLs (e.g. `https://abc123.expo.app`) without listing every subdomain explicitly. When suffixes are configured, CORS uses `AllowOrigin::predicate` so `allow_credentials(true)` continues to work.

### Example deployment config

```yaml
- name: ALLOWED_ORIGINS
  value: https://dev.neuland.app,https://web.neuland.app,http://localhost:3000
- name: ALLOWED_ORIGIN_SUFFIXES
  value: .expo.app
```

Suffixes may be written with or without a leading dot (`.expo.app` and `expo.app` are equivalent). Both `http://` and `https://` origins are accepted for suffix matches.

## Checklist

- [x] I've tested my changes on the backend
- [ ] I've tested my changes on the frontend
- [x] I've updated the documentation (if needed)
- [ ] I've reviewed the related issues, if any

## Additional notes

- Extracted CORS setup into `backend/src/cors_config.rs` with unit tests for suffix matching and security edge cases.
- When `ALLOWED_ORIGIN_SUFFIXES` is unset, behavior is unchanged from before (exact origins only).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f19f3-aae2-73d6-a92e-9380b3fbee7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f19f3-aae2-73d6-a92e-9380b3fbee7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

