### PR TITLE
perf: paginate event listings on the server

### DIFF
--- a/backend/migrations/20260729120000_add_events_list_indexes.down.sql
+++ b/backend/migrations/20260729120000_add_events_list_indexes.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX events_organizer_start_date_time_idx;
+DROP INDEX events_start_date_time_idx;

--- a/backend/migrations/20260729120000_add_events_list_indexes.up.sql
+++ b/backend/migrations/20260729120000_add_events_list_indexes.up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX events_start_date_time_idx ON events (start_date_time);
+CREATE INDEX events_organizer_start_date_time_idx ON events (organizer_id, start_date_time);

--- a/backend/src/dto.rs
+++ b/backend/src/dto.rs
@@ -137,6 +137,34 @@ pub struct ListEventsQuery {
     pub limit: Option<i64>,
     pub offset: Option<i64>,
     pub organizer_kind: Option<OrganizerKind>,
+    pub query: Option<String>,
+    pub visibility: Option<EventVisibility>,
+    pub starts_from: Option<DateTime<Utc>>,
+    pub starts_to: Option<DateTime<Utc>>,
+    pub sort: Option<EventSort>,
+    pub direction: Option<SortDirection>,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum EventVisibility {
+    Public,
+    Internal,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum EventSort {
+    StartDateTime,
+    EndDateTime,
+    TitleDe,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum SortDirection {
+    Asc,
+    Desc,
 }
 
 #[derive(Debug, Deserialize, ToSchema, IntoParams)]

--- a/backend/src/openapi.rs
+++ b/backend/src/openapi.rs
@@ -3,10 +3,11 @@ use utoipa::OpenApi;
 use crate::{
     dto::{
         ChangePasswordRequest, CreateApiTokenRequest, CreateEventRequest, CreateOrganizerRequest,
-        InitAccountRequest, InviteAdminRequest, ListAuditLogsQuery, ListEventsQuery,
-        ListPublicOrganizersQuery, LoginRequest, RequestPasswordResetRequest, ResetPasswordRequest,
-        SendNewsletterPreviewRequest, SetupTokenLookupRequest, UpdateAccountEmailRequest,
-        UpdateEventRequest, UpdateOrganizerPermissionsRequest, UpdateOrganizerRequest,
+        EventSort, EventVisibility, InitAccountRequest, InviteAdminRequest, ListAuditLogsQuery,
+        ListEventsQuery, ListPublicOrganizersQuery, LoginRequest, RequestPasswordResetRequest,
+        ResetPasswordRequest, SendNewsletterPreviewRequest, SetupTokenLookupRequest, SortDirection,
+        UpdateAccountEmailRequest, UpdateEventRequest, UpdateOrganizerPermissionsRequest,
+        UpdateOrganizerRequest,
     },
     models::{
         AdminWithInvite, AuditLogEntry, Event, InviteStatus, Organizer, OrganizerKind,
@@ -15,8 +16,8 @@ use crate::{
     responses::{
         AccountEmailUpdatedResponse, ApiTokenCreatedResponse, ApiTokenSummaryResponse,
         AuthUserResponse, ErrorResponse, HealthResponse, IcalEventResponse, NewsletterDataResponse,
-        OrganizerWithStatsResponse, PasswordResetRequestResponse, PublicEventResponse,
-        PublicOrganizerResponse, SetupTokenInfoResponse, SetupTokenResponse,
+        OrganizerWithStatsResponse, PaginatedEventsResponse, PasswordResetRequestResponse,
+        PublicEventResponse, PublicOrganizerResponse, SetupTokenInfoResponse, SetupTokenResponse,
     },
     routes,
 };
@@ -102,6 +103,9 @@ use crate::{
         CreateEventRequest,
         UpdateEventRequest,
         ListEventsQuery,
+        EventVisibility,
+        EventSort,
+        SortDirection,
         ListPublicOrganizersQuery,
         ListAuditLogsQuery,
         SendNewsletterPreviewRequest,
@@ -116,6 +120,7 @@ use crate::{
         AccountEmailUpdatedResponse,
         SetupTokenInfoResponse,
         NewsletterDataResponse,
+        PaginatedEventsResponse,
         PublicEventResponse, PublicOrganizerResponse, IcalEventResponse,
         InviteStatus,
         OrganizerKind

--- a/backend/src/responses.rs
+++ b/backend/src/responses.rs
@@ -2,11 +2,17 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-use crate::models::{AccountType, EventWithOrganizer, Organizer, OrganizerKind};
+use crate::models::{AccountType, Event, EventWithOrganizer, Organizer, OrganizerKind};
 
 #[derive(Debug, Serialize, ToSchema)]
 pub struct ErrorResponse {
     pub message: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct PaginatedEventsResponse {
+    pub items: Vec<Event>,
+    pub total: i64,
 }
 
 #[derive(Debug, Serialize, ToSchema)]

--- a/backend/src/routes/events.rs
+++ b/backend/src/routes/events.rs
@@ -14,12 +14,12 @@ use tracing::{instrument, warn};
 use crate::{
     app_state::AppState,
     dto::{
-        CreateEventRequest, ListEventsQuery, NewsletterDataQuery, SendNewsletterPreviewRequest,
-        UpdateEventRequest,
+        CreateEventRequest, EventSort, EventVisibility, ListEventsQuery, NewsletterDataQuery,
+        SendNewsletterPreviewRequest, SortDirection, UpdateEventRequest,
     },
     error::AppError,
     models::{AccountType, AuditType, Event, EventWithOrganizer, Organizer, OrganizerKind},
-    responses::{ErrorResponse, NewsletterDataResponse},
+    responses::{ErrorResponse, NewsletterDataResponse, PaginatedEventsResponse},
 };
 
 use super::shared::{
@@ -514,67 +514,66 @@ pub(crate) async fn send_newsletter_preview_with_user(
     path = "/api/v1/events",
     tag = "Events",
     params(ListEventsQuery),
-    responses((status = 200, description = "List events", body = [Event]), (status = 401, description = "Unauthorized", body = ErrorResponse))
+    responses((status = 200, description = "List events", body = PaginatedEventsResponse), (status = 401, description = "Unauthorized", body = ErrorResponse))
 )]
 #[instrument(skip(state, query_params, headers))]
 pub(crate) async fn list_events(
     State(state): State<AppState>,
     Query(query_params): Query<ListEventsQuery>,
     headers: HeaderMap,
-) -> Result<Json<Vec<Event>>, AppError> {
+) -> Result<Json<PaginatedEventsResponse>, AppError> {
     let user = current_user_from_headers(&headers, &state).await?;
     let scope = session_organizer_kind_scope(&state, &user).await?;
 
     let enforced_organizer_kind = match scope {
         SessionOrganizerKindScope::All => None,
         SessionOrganizerKindScope::OnlyKind(k) => Some(k),
-        SessionOrganizerKindScope::None => return Ok(Json(vec![])),
+        SessionOrganizerKindScope::None => {
+            return Ok(Json(PaginatedEventsResponse {
+                items: vec![],
+                total: 0,
+            }));
+        }
     };
+
+    let now = Utc::now();
+    let mut count_builder = QueryBuilder::<Postgres>::new(
+        "SELECT COUNT(*) FROM events e INNER JOIN organizers o ON e.organizer_id = o.id",
+    );
+    apply_event_filters(
+        &mut count_builder,
+        &query_params,
+        user.is_admin(),
+        enforced_organizer_kind,
+        now,
+    );
+    let total = count_builder
+        .build_query_scalar::<i64>()
+        .fetch_one(&state.db)
+        .await?;
 
     let mut builder = QueryBuilder::<Postgres>::new(
         "SELECT e.id, e.organizer_id, e.title_de, e.title_en, e.description_de, e.description_en, e.start_date_time, e.end_date_time, e.event_url, e.location, e.publish_app, e.publish_newsletter, e.publish_in_ical, e.publish_web, e.created_at, e.updated_at FROM events e INNER JOIN organizers o ON e.organizer_id = o.id",
     );
+    apply_event_filters(
+        &mut builder,
+        &query_params,
+        user.is_admin(),
+        enforced_organizer_kind,
+        now,
+    );
 
-    let mut has_where = false;
-
-    if user.is_admin() {
-        if let Some(organizer_id) = query_params.organizer_id {
-            builder
-                .push(" WHERE e.organizer_id = ")
-                .push_bind(organizer_id);
-            has_where = true;
-        }
-
-        if let Some(organizer_kind) = query_params.organizer_kind {
-            if has_where {
-                builder
-                    .push(" AND o.organizer_kind = ")
-                    .push_bind(organizer_kind);
-            } else {
-                builder
-                    .push(" WHERE o.organizer_kind = ")
-                    .push_bind(organizer_kind);
-                has_where = true;
-            }
-        }
-    } else if let Some(kind) = enforced_organizer_kind {
-        builder.push(" WHERE o.organizer_kind = ").push_bind(kind);
-        has_where = true;
-    }
-
-    if query_params.upcoming_only.unwrap_or(false) {
-        if has_where {
-            builder
-                .push(" AND e.end_date_time >= ")
-                .push_bind(Utc::now());
-        } else {
-            builder
-                .push(" WHERE e.end_date_time >= ")
-                .push_bind(Utc::now());
-        }
-    }
-
-    builder.push(" ORDER BY e.start_date_time ASC");
+    builder.push(" ORDER BY ");
+    builder.push(match query_params.sort {
+        Some(EventSort::EndDateTime) => "e.end_date_time",
+        Some(EventSort::TitleDe) => "e.title_de",
+        Some(EventSort::StartDateTime) | None => "e.start_date_time",
+    });
+    builder.push(match query_params.direction {
+        Some(SortDirection::Desc) => " DESC",
+        Some(SortDirection::Asc) | None => " ASC",
+    });
+    builder.push(", e.id ASC");
 
     if let Some(limit) = query_params.limit {
         builder.push(" LIMIT ").push_bind(limit.max(1));
@@ -588,7 +587,82 @@ pub(crate) async fn list_events(
         .fetch_all(&state.db)
         .await?;
 
-    Ok(Json(events))
+    Ok(Json(PaginatedEventsResponse {
+        items: events,
+        total,
+    }))
+}
+
+fn apply_event_filters(
+    builder: &mut QueryBuilder<Postgres>,
+    query_params: &ListEventsQuery,
+    is_admin: bool,
+    enforced_organizer_kind: Option<OrganizerKind>,
+    now: chrono::DateTime<Utc>,
+) {
+    let mut has_where = false;
+    let mut add_condition = |builder: &mut QueryBuilder<Postgres>| {
+        builder.push(if has_where { " AND " } else { " WHERE " });
+        has_where = true;
+    };
+
+    if is_admin {
+        if let Some(organizer_id) = query_params.organizer_id {
+            add_condition(builder);
+            builder.push("e.organizer_id = ").push_bind(organizer_id);
+        }
+
+        if let Some(organizer_kind) = query_params.organizer_kind {
+            add_condition(builder);
+            builder
+                .push("o.organizer_kind = ")
+                .push_bind(organizer_kind);
+        }
+    } else if let Some(kind) = enforced_organizer_kind {
+        add_condition(builder);
+        builder.push("o.organizer_kind = ").push_bind(kind);
+    }
+
+    if query_params.upcoming_only.unwrap_or(false) {
+        add_condition(builder);
+        builder.push("e.end_date_time >= ").push_bind(now);
+    }
+
+    if let Some(starts_from) = query_params.starts_from {
+        add_condition(builder);
+        builder.push("e.start_date_time >= ").push_bind(starts_from);
+    }
+
+    if let Some(starts_to) = query_params.starts_to {
+        add_condition(builder);
+        builder.push("e.start_date_time <= ").push_bind(starts_to);
+    }
+
+    if let Some(visibility) = &query_params.visibility {
+        add_condition(builder);
+        builder.push(match visibility {
+            EventVisibility::Public => "(e.publish_app OR e.publish_newsletter)",
+            EventVisibility::Internal => "NOT (e.publish_app OR e.publish_newsletter)",
+        });
+    }
+
+    if let Some(query) = query_params
+        .query
+        .as_deref()
+        .filter(|query| !query.trim().is_empty())
+    {
+        add_condition(builder);
+        builder
+            .push("(e.title_de ILIKE ")
+            .push_bind(format!("%{query}%"))
+            .push(" OR e.title_en ILIKE ")
+            .push_bind(format!("%{query}%"))
+            .push(" OR e.description_de ILIKE ")
+            .push_bind(format!("%{query}%"))
+            .push(" OR e.description_en ILIKE ")
+            .push_bind(format!("%{query}%"))
+            .push(")");
+    }
 }
 
 #[utoipa::path(

--- a/frontend/app/(app)/analytics/page.tsx
+++ b/frontend/app/(app)/analytics/page.tsx
@@ -75,8 +75,11 @@ export default function AnalyticsPage() {
 	const { data: events = [] } = useQuery<ApiEvent[]>({
 		queryKey: ['events'],
 		queryFn: async () => {
-			const response = await listEvents({ throwOnError: true })
-			return response.data ?? []
+			const response = await listEvents({
+				query: { limit: 5000 },
+				throwOnError: true
+			})
+			return response.data?.items ?? []
 		}
 	})
 	const { data: organizers = [] } = useQuery<ApiOrganizer[]>({

--- a/frontend/app/(app)/page.tsx
+++ b/frontend/app/(app)/page.tsx
@@ -57,8 +57,11 @@ export default function Dashboard() {
 	const { data: events = [], isLoading: eventsLoading } = useQuery<ApiEvent[]>({
 		queryKey: ['events'],
 		queryFn: async () => {
-			const response = await listEvents({ throwOnError: true })
-			return response.data ?? []
+			const response = await listEvents({
+				query: { limit: 5000 },
+				throwOnError: true
+			})
+			return response.data?.items ?? []
 		}
 	})
 	const { data: organizers = [] } = useQuery<ApiOrganizer[]>({

--- a/frontend/client/types.gen.ts
+++ b/frontend/client/types.gen.ts
@@ -114,6 +114,10 @@ export type Event = {
     updated_at: string;
 };
 
+export type EventSort = 'start_date_time' | 'end_date_time' | 'title_de';
+
+export type EventVisibility = 'public' | 'internal';
+
 export type EventWithOrganizer = {
     created_at: string;
     description_de?: string | null;
@@ -175,11 +179,22 @@ export type ListAuditLogsQuery = {
 };
 
 export type ListEventsQuery = {
+    direction?: 'asc' | 'desc' | null;
     limit?: number | null;
     offset?: number | null;
     organizer_id?: number | null;
     organizer_kind?: null | OrganizerKind;
+    query?: string | null;
+    sort?: EventSort | null;
+    starts_from?: string | null;
+    starts_to?: string | null;
     upcoming_only?: boolean | null;
+    visibility?: EventVisibility | null;
+};
+
+export type PaginatedEventsResponse = {
+    items: Array<Event>;
+    total: number;
 };
 
 export type ListPublicOrganizersQuery = {
@@ -787,6 +802,12 @@ export type ListEventsData = {
         limit?: number;
         offset?: number;
         organizer_kind?: OrganizerKind;
+        query?: string;
+        visibility?: EventVisibility;
+        starts_from?: string;
+        starts_to?: string;
+        sort?: EventSort;
+        direction?: 'asc' | 'desc';
     };
     url: '/api/v1/events';
 };
@@ -804,7 +825,7 @@ export type ListEventsResponses = {
     /**
      * List events
      */
-    200: Array<Event>;
+    200: PaginatedEventsResponse;
 };
 
 export type ListEventsResponse = ListEventsResponses[keyof ListEventsResponses];

--- a/frontend/components/data-table/data-table.tsx
+++ b/frontend/components/data-table/data-table.tsx
@@ -7,6 +7,7 @@ import {
 	getPaginationRowModel,
 	getSortedRowModel,
 	type OnChangeFn,
+	type PaginationState,
 	type Row,
 	type SortingState,
 	type TableState,
@@ -40,8 +41,16 @@ type DataTableProps<TData, TValue> = {
 	data: TData[]
 	onClick?: (item: TData) => void
 	initialSorting?: SortingState
+	sorting?: SortingState
+	onSortingChange?: OnChangeFn<SortingState>
 	columnFilters?: ColumnFiltersState
 	onColumnFiltersChange?: (filters: ColumnFiltersState) => void
+	pagination?: PaginationState
+	onPaginationChange?: OnChangeFn<PaginationState>
+	pageCount?: number
+	manualFiltering?: boolean
+	manualPagination?: boolean
+	manualSorting?: boolean
 	renderMobileRows?: (args: { rows: Row<TData>[] }) => ReactNode
 } & (
 	| {
@@ -91,8 +100,16 @@ export function DataTable<TData, TValue>({
 	filterOptions,
 	initialPageSize,
 	initialSorting,
+	sorting: sortingProp,
+	onSortingChange,
 	columnFilters: columnFiltersProp,
 	onColumnFiltersChange,
+	pagination: paginationProp,
+	onPaginationChange,
+	pageCount,
+	manualFiltering = false,
+	manualPagination = false,
+	manualSorting = false,
 	renderMobileRows
 }: DataTableProps<TData, TValue>) {
 	'use no memo'
@@ -103,6 +120,13 @@ export function DataTable<TData, TValue>({
 	const [hasRestoredTableState, setHasRestoredTableState] = useState(false)
 
 	const isControlled = columnFiltersProp !== undefined
+	const isSortingControlled = sortingProp !== undefined
+	const activeSorting = sortingProp ?? sorting
+	const [pagination, setPagination] = useState<PaginationState>({
+		pageIndex: 0,
+		pageSize: initialPageSize ?? 10
+	})
+	const activePagination = paginationProp ?? pagination
 	const columnFilters = isControlled
 		? (columnFiltersProp ?? [])
 		: uncontrolledColumnFilters
@@ -133,7 +157,7 @@ export function DataTable<TData, TValue>({
 
 			const savedState: Partial<TableState> = JSON.parse(serializedState)
 
-			if (isSortingState(savedState.sorting)) {
+			if (!isSortingControlled && isSortingState(savedState.sorting)) {
 				setSorting(savedState.sorting)
 			}
 
@@ -145,14 +169,14 @@ export function DataTable<TData, TValue>({
 		} finally {
 			setHasRestoredTableState(true)
 		}
-	}, [isControlled, tableStateKey])
+	}, [isControlled, isSortingControlled, tableStateKey])
 
 	useEffect(() => {
 		if (!hasRestoredTableState) {
 			return
 		}
 
-		const stateToSave: Partial<TableState> = { sorting }
+		const stateToSave: Partial<TableState> = { sorting: activeSorting }
 
 		if (!isControlled) {
 			stateToSave.columnFilters = columnFilters
@@ -160,7 +184,7 @@ export function DataTable<TData, TValue>({
 
 		localStorage.setItem(tableStateKey, JSON.stringify(stateToSave))
 	}, [
-		sorting,
+		activeSorting,
 		columnFilters,
 		tableStateKey,
 		isControlled,
@@ -171,8 +195,9 @@ export function DataTable<TData, TValue>({
 		data,
 		columns,
 		state: {
-			sorting,
-			columnFilters
+			sorting: activeSorting,
+			columnFilters,
+			pagination: activePagination
 		},
 		initialState: {
 			pagination: {
@@ -181,8 +206,13 @@ export function DataTable<TData, TValue>({
 			}
 		},
 		getCoreRowModel: getCoreRowModel(),
-		onSortingChange: setSorting,
+		onSortingChange: onSortingChange ?? setSorting,
 		onColumnFiltersChange: handleColumnFiltersChange,
+		onPaginationChange: onPaginationChange ?? setPagination,
+		manualFiltering,
+		manualPagination,
+		manualSorting,
+		pageCount,
 		getPaginationRowModel: enablePagination
 			? getPaginationRowModel()
 			: undefined,

--- a/frontend/components/events/events-dashboard.tsx
+++ b/frontend/components/events/events-dashboard.tsx
@@ -1,16 +1,24 @@
 'use client'
 
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import type { ColumnFiltersState } from '@tanstack/react-table'
+import type {
+	ColumnFiltersState,
+	OnChangeFn,
+	PaginationState,
+	SortingState
+} from '@tanstack/react-table'
 import { startOfDay } from 'date-fns'
 import dynamic from 'next/dynamic'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+	useCallback,
+	useDeferredValue,
+	useEffect,
+	useMemo,
+	useState
+} from 'react'
 import { toast } from 'sonner'
 import { deleteEvent, listEvents, listOrganizers } from '@/client'
-import type {
-	Event as ApiEvent,
-	Organizer as ApiOrganizer
-} from '@/client/types.gen'
+import type { Organizer as ApiOrganizer } from '@/client/types.gen'
 import { DataTable } from '@/components/data-table/data-table'
 import { EventsHeader } from '@/components/events/events-header'
 import { EventsMobileList } from '@/components/events/events-mobile-list'
@@ -123,6 +131,13 @@ export function EventsDashboard({
 	'use no memo'
 	const qc = useQueryClient()
 	const [viewMode, setViewMode] = useState<'table' | 'calendar'>('table')
+	const [pagination, setPagination] = useState<PaginationState>({
+		pageIndex: 0,
+		pageSize: 10
+	})
+	const [sorting, setSorting] = useState<SortingState>([
+		{ id: 'start_date_time', desc: false }
+	])
 	const defaultDateFilter = useMemo(() => createUpcomingEventsFilter(), [])
 	const [columnFiltersState, setColumnFiltersState] =
 		useState<ColumnFiltersState>(() =>
@@ -134,6 +149,7 @@ export function EventsDashboard({
 				| ColumnFiltersState
 				| ((previous: ColumnFiltersState) => ColumnFiltersState)
 		) => {
+			setPagination((previous) => ({ ...previous, pageIndex: 0 }))
 			setColumnFiltersState((previous) => {
 				const next = typeof updater === 'function' ? updater(previous) : updater
 
@@ -142,7 +158,50 @@ export function EventsDashboard({
 		},
 		[]
 	)
+	const handleSortingChange = useCallback<OnChangeFn<SortingState>>(
+		(updater) => {
+			setPagination((previous) => ({ ...previous, pageIndex: 0 }))
+			setSorting((previous) =>
+				typeof updater === 'function' ? updater(previous) : updater
+			)
+		},
+		[]
+	)
 	const columnFilters = columnFiltersState
+	const eventQueryFilters = useMemo(() => {
+		const title = columnFilters.find((filter) => filter.id === 'title_de')
+		const organizer = columnFilters.find((filter) => filter.id === 'organizer')
+		const visibility = columnFilters.find(
+			(filter) => filter.id === 'visibility'
+		)
+		const dateRange = columnFilters.find(
+			(filter) => filter.id === DATE_FILTER_ID
+		)
+		const range = dateRange?.value as DateFilterValue
+		const sort = sorting[0]
+
+		return {
+			query:
+				typeof title?.value === 'string' ? title.value || undefined : undefined,
+			organizer_id: Array.isArray(organizer?.value)
+				? Number(organizer.value[0]) || undefined
+				: undefined,
+			visibility: Array.isArray(visibility?.value)
+				? (visibility.value[0] as 'public' | 'internal' | undefined)
+				: undefined,
+			starts_from: toValidDate(range?.from)?.toISOString(),
+			starts_to: toValidDate(range?.to)?.toISOString(),
+			sort: (sort?.id === 'end_date_time' || sort?.id === 'title_de'
+				? sort.id
+				: 'start_date_time') as
+				| 'start_date_time'
+				| 'end_date_time'
+				| 'title_de',
+			direction: (sort?.desc ? 'desc' : 'asc') as 'asc' | 'desc'
+		}
+	}, [columnFilters, sorting])
+	const deferredEventQueryFilters = useDeferredValue(eventQueryFilters)
+
 	const { data: meData } = useQuery({
 		queryKey: ['auth', 'me'],
 		queryFn: me
@@ -150,11 +209,32 @@ export function EventsDashboard({
 	const organizerId = meData?.organizer_id ?? undefined
 	const isAdmin = meData?.account_type === 'ADMIN'
 
-	const { data, isLoading, error, refetch } = useQuery<ApiEvent[]>({
-		queryKey: ['events'],
+	const { data, isLoading, error, refetch } = useQuery({
+		queryKey: ['events', pagination, deferredEventQueryFilters],
 		queryFn: async () => {
-			const response = await listEvents({ throwOnError: true })
-			return response.data ?? []
+			const response = await listEvents({
+				query: {
+					...deferredEventQueryFilters,
+					limit: pagination.pageSize,
+					offset: pagination.pageIndex * pagination.pageSize
+				},
+				throwOnError: true
+			})
+			return response.data
+		}
+	})
+	const { data: calendarData } = useQuery({
+		queryKey: ['events', 'calendar', deferredEventQueryFilters],
+		enabled: viewMode === 'calendar',
+		queryFn: async () => {
+			const response = await listEvents({
+				query: {
+					...deferredEventQueryFilters,
+					limit: 5000
+				},
+				throwOnError: true
+			})
+			return response.data
 		}
 	})
 
@@ -178,7 +258,8 @@ export function EventsDashboard({
 		[organizersRaw]
 	)
 
-	const events = useMemo(() => data ?? [], [data])
+	const events = data?.items ?? []
+	const calendarEvents = calendarData?.items ?? []
 
 	const organizerFilterValues = useMemo(() => {
 		const organizerFilter = columnFilters.find(
@@ -264,16 +345,6 @@ export function EventsDashboard({
 		[organizerId, setColumnFilters]
 	)
 
-	const calendarEvents = useMemo(() => {
-		if (organizerFilterValues.length === 0) {
-			return events
-		}
-
-		return events.filter((event) =>
-			organizerFilterValues.includes(event.organizer_id.toString())
-		)
-	}, [events, organizerFilterValues])
-
 	const onDelete = useCallback(
 		async (id: number) => {
 			await deleteEvent({ path: { id } })
@@ -346,6 +417,14 @@ export function EventsDashboard({
 					enableFilter
 					enablePagination
 					initialPageSize={10}
+					pagination={pagination}
+					onPaginationChange={setPagination}
+					pageCount={Math.ceil((data?.total ?? 0) / pagination.pageSize)}
+					manualPagination
+					sorting={sorting}
+					onSortingChange={handleSortingChange}
+					manualSorting
+					manualFiltering
 					columnFilters={columnFilters}
 					onColumnFiltersChange={setColumnFilters}
 					renderMobileRows={({ rows }) => (
@@ -366,6 +445,7 @@ export function EventsDashboard({
 							{
 								column: 'organizer',
 								title: 'Organisation',
+								mode: 'single',
 								options: organizerOptions
 							},
 							{


### PR DESCRIPTION
## Summary
- return paginated event results with total counts
- add server-side event search, filtering, sorting, and indexes
- use server-driven pagination, sorting, and filtering in the events workspace

## Validation
- SQLX_OFFLINE=true cargo clippy --all-targets --all-features -- -D warnings
- bun run lint
- bun run build